### PR TITLE
Migrate CodeQL workflow to reusable workflow

### DIFF
--- a/.github/workflows/codeql-workflow.yml
+++ b/.github/workflows/codeql-workflow.yml
@@ -13,35 +13,6 @@ on:
 
 jobs:
   analyse:
-    name: CodeQL Analyse of kernel application
-    strategy: 
-      matrix:
-        include:
-          - SDK: "$NANOS_SDK"
-            artifact: kernel-app-nanoS
-          - SDK: "$NANOX_SDK"
-            artifact: kernel-app-nanoX
-          - SDK: "$NANOSP_SDK"
-            artifact: kernel-app-nanoSP
-        language: [ 'cpp' ]
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-legacy:latest
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v3
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-    
-      - name: Build
-        run: |
-          make BOLOS_SDK=${{ matrix.SDK }}
-        
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
-
+    name: Call Ledger CodeQL analysis
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_codeql_checks.yml@v1
+    secrets: inherit


### PR DESCRIPTION
This PR migrates the CodeQL workflow to use the centralized reusable workflow from `LedgerHQ/ledger-app-workflows`.